### PR TITLE
chore: add test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Test
+
+on:
+  push:
+
+jobs:
+  test:
+    name: 'Test'
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+            go-version: '1.24'
+            cache: 'true'
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '4.0.3'
+
+      - name: Install Taskfile
+        run: go install github.com/go-task/task/v3/cmd/task@latest
+
+      - name: Run tests
+        run: task test
+
+      - name: Run basic example
+        run: task basic-example
+
+      # Disabled for now until all WIT types are supported
+      # - name: Run all types example
+      #   run: task all-types-example


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate testing and example verification runs for the witigo package. The workflow sets up dependencies and runs tasks to ensure code quality and basic functionality.

* Added `.github/workflows/test.yml` to trigger the CI workflow on every push
* Temporarily disables the "all types example" task until full WIT type support is available