### PR TITLE
feat: add variant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The generated package will include all necessary bindings and types to interact 
     - [x] `list`
     - [x] `record`
     - [x] `option`
-    - [ ] `variant`
+    - [x] `variant`
     - [ ] `result`
     - [ ] `tuple`
     - [ ] `flags`
@@ -71,7 +71,7 @@ The generated package will include all necessary bindings and types to interact 
     - [x] `list`
     - [x] `record`
     - [x] `option`
-    - [ ] `variant`
+    - [x] `variant`
     - [ ] `result`
     - [ ] `tuple`
     - [ ] `flags`

--- a/examples/all-types/lib/src/CMakeLists.txt
+++ b/examples/all-types/lib/src/CMakeLists.txt
@@ -9,6 +9,8 @@ wit_bindgen(
 add_executable(all_types_example component.cpp ${bindings})
 target_link_libraries(all_types_example PRIVATE wasi_sdk_reactor_module)
 set_target_properties(all_types_example PROPERTIES OUTPUT_NAME "all_types_example.wasm")
+target_compile_options(all_types_example PRIVATE -Wno-narrowing)
+
 
 # Add WIT bindings to interface/include directory
 target_include_directories(all_types_example PUBLIC ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/all-types/lib/src/component.cpp
+++ b/examples/all-types/lib/src/component.cpp
@@ -85,11 +85,12 @@ void exports_all_types_example_variant_func(
   } else if (input->tag == ALL_TYPES_EXAMPLE_ALLOWED_DESTINATIONS_RESTRICTED) {
     ret->tag = ALL_TYPES_EXAMPLE_ALLOWED_DESTINATIONS_RESTRICTED;
     ret->val.restricted.len = input->val.restricted.len;
-    ret->val.restricted.ptr = (all_types_example_string_t*)realloc(
-        ret->val.restricted.ptr,
-        input->val.restricted.len * sizeof(all_types_example_string_t));
-    memcpy(ret->val.restricted.ptr, input->val.restricted.ptr,
-           input->val.restricted.len * sizeof(all_types_example_string_t));
+    ret->val.restricted.ptr = (all_types_example_string_t*)malloc(
+        ret->val.restricted.len * sizeof(ret->val.restricted.ptr[0]));
+    for (size_t i = 0; i < input->val.restricted.len; i++) {
+      exports_all_types_example_string_func(&input->val.restricted.ptr[i],
+                                            &ret->val.restricted.ptr[i]);
+    }
   }
 }
 

--- a/examples/all-types/lib/src/component.cpp
+++ b/examples/all-types/lib/src/component.cpp
@@ -119,3 +119,66 @@ void exports_all_types_example_no_return_func(bool) {
   // It can be used to demonstrate a function that performs an action
   // without returning any data.
 }
+
+// complex-variant-func logic:
+//  - empty      -> stays empty
+//  - number(n)  -> number(n+1)
+//  - floating(f)   -> floating(f*2)
+//  - big(u)     -> big(u-1)
+//  - text(s)    -> text(s + "!")
+//  - bytes(b)   -> bytes(b concatenated with 0xff)
+//  - pair(r)    -> pair({ x: r.x-1, y: r.y+1 })
+void exports_all_types_example_complex_variant_func(
+    all_types_example_complex_union_t* input,
+    all_types_example_complex_union_t* ret) {
+  switch (input->tag) {
+    case ALL_TYPES_EXAMPLE_COMPLEX_UNION_EMPTY: {
+      ret->tag = ALL_TYPES_EXAMPLE_COMPLEX_UNION_EMPTY;
+      break;
+    }
+    case ALL_TYPES_EXAMPLE_COMPLEX_UNION_NUMBER: {
+      ret->tag = ALL_TYPES_EXAMPLE_COMPLEX_UNION_NUMBER;
+      ret->val.number = input->val.number + 1;
+      break;
+    }
+    case ALL_TYPES_EXAMPLE_COMPLEX_UNION_FLOATING: {
+      ret->tag = ALL_TYPES_EXAMPLE_COMPLEX_UNION_FLOATING;
+      ret->val.floating = input->val.floating * 2.0f;
+      break;
+    }
+    case ALL_TYPES_EXAMPLE_COMPLEX_UNION_BIG: {
+      ret->tag = ALL_TYPES_EXAMPLE_COMPLEX_UNION_BIG;
+      ret->val.big = input->val.big - 1;
+      break;
+    }
+    case ALL_TYPES_EXAMPLE_COMPLEX_UNION_TEXT: {
+      ret->tag = ALL_TYPES_EXAMPLE_COMPLEX_UNION_TEXT;
+      // Reallocate with space for '!'
+      size_t new_len = input->val.text.len + 1;
+      ret->val.text.len = new_len;
+      ret->val.text.ptr = (uint8_t*)malloc(new_len);
+      memcpy(ret->val.text.ptr, input->val.text.ptr, input->val.text.len);
+      ret->val.text.ptr[new_len - 1] = '!';
+      break;
+    }
+    case ALL_TYPES_EXAMPLE_COMPLEX_UNION_BYTES: {
+      ret->tag = ALL_TYPES_EXAMPLE_COMPLEX_UNION_BYTES;
+      size_t new_len = input->val.bytes.len + 1;
+      ret->val.bytes.len = new_len;
+      ret->val.bytes.ptr = (uint8_t*)malloc(new_len);
+      memcpy(ret->val.bytes.ptr, input->val.bytes.ptr, input->val.bytes.len);
+      ret->val.bytes.ptr[new_len - 1] = 0xff;
+      break;
+    }
+    case ALL_TYPES_EXAMPLE_COMPLEX_UNION_PAIR: {
+      ret->tag = ALL_TYPES_EXAMPLE_COMPLEX_UNION_PAIR;
+      ret->val.pair.x = input->val.pair.x - 1;
+      ret->val.pair.y = input->val.pair.y + 1;
+      break;
+    }
+    default: {
+      ret->tag = ALL_TYPES_EXAMPLE_COMPLEX_UNION_EMPTY;
+      break;
+    }
+  }
+}

--- a/examples/all-types/lib/src/component.wit
+++ b/examples/all-types/lib/src/component.wit
@@ -44,6 +44,22 @@ world all-types-example {
         restricted(list<string>),
     }
 
+    // A complex variant exercising multiple payload shapes for testing
+    record small-record {
+        x: s16,
+        y: u64,
+    }
+
+    variant complex-union {
+        empty,
+        number(s32),
+        floating(f32),
+        big(u64),
+        text(string),
+        bytes(list<u8>),
+        pair(small-record),
+    }
+
     enum color {
         hot-pink,
         lime-green,
@@ -60,6 +76,7 @@ world all-types-example {
     export option-func: func (input: option<u64>) -> option<u64>;
     export result-func: func (input: result<u64, string>) -> result<u64, string>;
     export variant-func: func (input: allowed-destinations) -> allowed-destinations;
+    export complex-variant-func: func (input: complex-union) -> complex-union;
     export enum-func: func (input: color) -> color;
     export int64-func: func (input: s64) -> s64;
     export no-return-func: func (flag: bool);

--- a/examples/all-types/main.go
+++ b/examples/all-types/main.go
@@ -64,19 +64,19 @@ func main() {
 	}
 	fmt.Printf("Result of EnumFunc: %+v\n", enumFuncResult)
 
-	resultFuncResult, err := instance.ResultFunc(all_types_example_component.Uint64StringResult{Ok: 42, Error: "Success"})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error calling ResultFunc: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Printf("Result of ResultFunc: %+v\n", resultFuncResult)
-
 	variantFuncResult, err := instance.VariantFunc(all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeAny})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error calling VariantFunc: %v\n", err)
 		os.Exit(1)
 	}
 	fmt.Printf("Result of VariantFunc: %+v\n", variantFuncResult)
+
+	resultFuncResult, err := instance.ResultFunc(all_types_example_component.Uint64StringResult{Ok: 42, Error: "Success"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error calling ResultFunc: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Result of ResultFunc: %+v\n", resultFuncResult)
 
 	tupleFuncResult, err := instance.TupleFunc(all_types_example_component.StringUint32Tuple{Elem0: "example", Elem1: 12345})
 	if err != nil {

--- a/examples/all-types/main_test.go
+++ b/examples/all-types/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	all_types_example_component "github.com/rioam2/witigo/examples/all-types/generated"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEnum(t *testing.T) {
@@ -33,13 +34,45 @@ func TestEnum(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := instance.EnumFunc(tt.input)
-			if err != nil {
-				t.Fatalf("Enum operation failed: %v", err)
-			}
+			assert.NoError(t, err)
+			assert.Equal(t, result, tt.expected)
+		})
+	}
+}
 
-			if result != tt.expected {
-				t.Errorf("Expected %v, got %v", tt.expected, result)
-			}
+func TestVariant(t *testing.T) {
+	instance, err := all_types_example_component.New(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to create instance: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		input    all_types_example_component.AllowedDestinationsVariant
+		expected all_types_example_component.AllowedDestinationsVariant
+	}{
+		{
+			name:     "Test with Any variant type",
+			input:    all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeAny},
+			expected: all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeAny},
+		},
+		{
+			name:     "Test with Email variant type",
+			input:    all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeNone},
+			expected: all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeNone},
+		},
+		{
+			name:     "Test with Phone variant type",
+			input:    all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeRestricted, Restricted: []string{"123-456-7890"}},
+			expected: all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeRestricted, Restricted: []string{"123-456-7890"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := instance.VariantFunc(tt.input)
+			assert.NoError(t, err)
+			assert.Equal(t, result, tt.expected)
 		})
 	}
 }

--- a/examples/all-types/main_test.go
+++ b/examples/all-types/main_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const createInstanceErrFmt = "Failed to create instance: %v"
+
 func TestEnum(t *testing.T) {
 	instance, err := all_types_example_component.New(context.Background())
 	if err != nil {
-		t.Fatalf("Failed to create instance: %v", err)
+		t.Fatalf(createInstanceErrFmt, err)
 	}
 
 	tests := []struct {
@@ -43,7 +45,7 @@ func TestEnum(t *testing.T) {
 func TestVariant(t *testing.T) {
 	instance, err := all_types_example_component.New(context.Background())
 	if err != nil {
-		t.Fatalf("Failed to create instance: %v", err)
+		t.Fatalf(createInstanceErrFmt, err)
 	}
 
 	tests := []struct {
@@ -57,12 +59,12 @@ func TestVariant(t *testing.T) {
 			expected: all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeAny},
 		},
 		{
-			name:     "Test with Email variant type",
+			name:     "Test with None variant type",
 			input:    all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeNone},
 			expected: all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeNone},
 		},
 		{
-			name:     "Test with Phone variant type",
+			name:     "Test with Restricted variant type",
 			input:    all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeRestricted, Restricted: []string{"123-456-7890"}},
 			expected: all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeRestricted, Restricted: []string{"123-456-7890 - modified by C++"}},
 		},
@@ -73,6 +75,105 @@ func TestVariant(t *testing.T) {
 			result, err := instance.VariantFunc(tt.input)
 			assert.NoError(t, err)
 			assert.Equal(t, result, tt.expected)
+		})
+	}
+}
+
+func TestComplexVariant(t *testing.T) {
+	instance, err := all_types_example_component.New(context.Background())
+	if err != nil {
+		t.Fatalf(createInstanceErrFmt, err)
+	}
+
+	// Table covers all cases of ComplexUnionVariant transformation rules
+	cases := []struct {
+		name     string
+		input    all_types_example_component.ComplexUnionVariant
+		expected all_types_example_component.ComplexUnionVariant
+	}{
+		{
+			name: "empty->empty",
+			input: all_types_example_component.ComplexUnionVariant{
+				Type: all_types_example_component.ComplexUnionVariantTypeEmpty,
+			},
+			expected: all_types_example_component.ComplexUnionVariant{
+				Type: all_types_example_component.ComplexUnionVariantTypeEmpty,
+			},
+		},
+		{
+			name: "number inc",
+			input: all_types_example_component.ComplexUnionVariant{
+				Type:   all_types_example_component.ComplexUnionVariantTypeNumber,
+				Number: 41,
+			},
+			expected: all_types_example_component.ComplexUnionVariant{
+				Type:   all_types_example_component.ComplexUnionVariantTypeNumber,
+				Number: 42,
+			},
+		},
+		{
+			name: "float double",
+			input: all_types_example_component.ComplexUnionVariant{
+				Type:     all_types_example_component.ComplexUnionVariantTypeFloating,
+				Floating: 3.5,
+			},
+			expected: all_types_example_component.ComplexUnionVariant{
+				Type:     all_types_example_component.ComplexUnionVariantTypeFloating,
+				Floating: 7.0,
+			},
+		},
+		{
+			name: "big decrement",
+			input: all_types_example_component.ComplexUnionVariant{
+				Type: all_types_example_component.ComplexUnionVariantTypeBig,
+				Big:  100,
+			},
+			expected: all_types_example_component.ComplexUnionVariant{
+				Type: all_types_example_component.ComplexUnionVariantTypeBig,
+				Big:  99,
+			},
+		},
+		{
+			name: "text append !",
+			input: all_types_example_component.ComplexUnionVariant{
+				Type: all_types_example_component.ComplexUnionVariantTypeText,
+				Text: "hi",
+			},
+			expected: all_types_example_component.ComplexUnionVariant{
+				Type: all_types_example_component.ComplexUnionVariantTypeText,
+				Text: "hi!",
+			},
+		},
+		{
+			name: "bytes append ff",
+			input: all_types_example_component.ComplexUnionVariant{
+				Type:  all_types_example_component.ComplexUnionVariantTypeBytes,
+				Bytes: []uint8{0x01, 0x02},
+			},
+			expected: all_types_example_component.ComplexUnionVariant{
+				Type:  all_types_example_component.ComplexUnionVariantTypeBytes,
+				Bytes: []uint8{0x01, 0x02, 0xff},
+			},
+		},
+		{
+			name: "pair transform",
+			input: all_types_example_component.ComplexUnionVariant{
+				Type: all_types_example_component.ComplexUnionVariantTypePair,
+				Pair: all_types_example_component.SmallRecordRecord{X: 5, Y: 10},
+			},
+			expected: all_types_example_component.ComplexUnionVariant{
+				Type: all_types_example_component.ComplexUnionVariantTypePair,
+				Pair: all_types_example_component.SmallRecordRecord{X: 4, Y: 11},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			out, err := instance.ComplexVariantFunc(c.input)
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, out)
 		})
 	}
 }

--- a/examples/all-types/main_test.go
+++ b/examples/all-types/main_test.go
@@ -37,7 +37,7 @@ func TestEnum(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := instance.EnumFunc(tt.input)
 			assert.NoError(t, err)
-			assert.Equal(t, result, tt.expected)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -74,7 +74,7 @@ func TestVariant(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := instance.VariantFunc(tt.input)
 			assert.NoError(t, err)
-			assert.Equal(t, result, tt.expected)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/examples/all-types/main_test.go
+++ b/examples/all-types/main_test.go
@@ -64,7 +64,7 @@ func TestVariant(t *testing.T) {
 		{
 			name:     "Test with Phone variant type",
 			input:    all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeRestricted, Restricted: []string{"123-456-7890"}},
-			expected: all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeRestricted, Restricted: []string{"123-456-7890"}},
+			expected: all_types_example_component.AllowedDestinationsVariant{Type: all_types_example_component.AllowedDestinationsVariantTypeRestricted, Restricted: []string{"123-456-7890 - modified by C++"}},
 		},
 	}
 

--- a/pkg/abi/parameters.go
+++ b/pkg/abi/parameters.go
@@ -46,7 +46,9 @@ func WriteParameter(opts AbiOptions, value any) (params []Parameter, free AbiFre
 		return WriteParameterList(opts, value)
 	case reflect.Struct:
 		structName := rv.Type().Name()
-		if isStructRecordType(rv) {
+		if isStructVariantType(rv) {
+			return WriteParameterVariant(opts, value)
+		} else if isStructRecordType(rv) {
 			return WriteParameterRecord(opts, value)
 		} else if isStructOptionType(rv) {
 			return WriteParameterOption(opts, value)

--- a/pkg/abi/variant.go
+++ b/pkg/abi/variant.go
@@ -1,0 +1,201 @@
+package abi
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// ReadVariant reads a variant from memory at the specified pointer into the result.
+// Memory layout (current implementation):
+//
+//	[ discriminant (size=SizeOf(Type field)) ][ payload (active case only, aligned) ]
+//
+// The overall allocation size equals discriminant size + max(size(case_i)) rounded up
+// to the maximum alignment of all fields. This mirrors a tagged union representation.
+func ReadVariant(opts AbiOptions, ptr uint64, result any) error {
+	rv := reflect.ValueOf(result)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return errors.New("must pass a non-nil pointer result")
+	}
+	rv = rv.Elem()
+	if !isStructVariantType(rv) {
+		return fmt.Errorf("result must be a variant pointer, got %s", rv.Type().Name())
+	}
+	if rv.NumField() == 0 {
+		return errors.New("variant struct missing fields")
+	}
+
+	// Read discriminant into first field
+	discriminantField := rv.Field(0)
+	discriminantSize := SizeOf(discriminantField.Interface())
+	discriminantAlign := AlignmentOf(discriminantField.Interface())
+	discriminantPtr := AlignTo(ptr, discriminantAlign)
+	// allocate a temporary variable to read into then set (so we invoke int logic)
+	tmpPtrVal := reflect.New(discriminantField.Type())
+	if err := ReadInt(opts, discriminantPtr, tmpPtrVal.Interface()); err != nil {
+		return fmt.Errorf("failed to read variant discriminant: %w", err)
+	}
+	discriminantField.Set(tmpPtrVal.Elem())
+
+	discrVal := uint64(0)
+	if discriminantField.CanUint() {
+		discrVal = discriminantField.Uint()
+	} else if discriminantField.CanInt() {
+		discrVal = uint64(discriminantField.Int())
+	} else {
+		return fmt.Errorf("discriminant field type %s not int/uint", discriminantField.Type())
+	}
+
+	caseIndex := int(discrVal)
+	numCases := rv.NumField() - 1
+	if caseIndex < 0 || caseIndex >= numCases { // invalid discriminant
+		return fmt.Errorf("variant discriminant %d out of range [0,%d)", caseIndex, numCases)
+	}
+
+	// Active case field is offset +1 from Type field
+	activeField := rv.Field(caseIndex + 1)
+	// Empty struct payload -> nothing further to read
+	if activeField.Kind() == reflect.Struct && activeField.Type().NumField() == 0 {
+		return nil
+	}
+
+	valuePtr := AlignTo(discriminantPtr+discriminantSize, AlignmentOf(activeField.Interface()))
+	return Read(opts, valuePtr, activeField.Addr().Interface())
+}
+
+// WriteVariant writes a variant value to linear memory and returns the pointer & free callback.
+func WriteVariant(opts AbiOptions, value any, ptrHint *uint64) (ptr uint64, free AbiFreeCallback, err error) {
+	ptr = 0
+	freeCallbacks := []AbiFreeCallback{}
+	free = wrapFreeCallbacks(&freeCallbacks)
+
+	rv := reflect.ValueOf(value)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if !rv.IsValid() {
+		return ptr, free, errors.New("must pass a valid variant value")
+	}
+	if !isStructVariantType(rv) {
+		return ptr, free, fmt.Errorf("value must be a variant, got %s", rv.Kind())
+	}
+	if rv.NumField() == 0 {
+		return ptr, free, errors.New("variant struct missing fields")
+	}
+
+	size := SizeOf(value)
+	alignment := AlignmentOf(value)
+	if ptrHint != nil && *ptrHint != 0 {
+		ptr = AlignTo(*ptrHint, alignment)
+	} else {
+		var freeVar AbiFreeCallback
+		ptr, freeVar, err = abiMalloc(opts, size, alignment)
+		if err != nil {
+			return ptr, free, err
+		}
+		freeCallbacks = append(freeCallbacks, freeVar)
+	}
+
+	discrField := rv.Field(0)
+	discrSize := SizeOf(discrField.Interface())
+	discrAlign := AlignmentOf(discrField.Interface())
+	discrPtr := AlignTo(ptr, discrAlign)
+
+	// Serialize discriminant bytes
+	bytes := make([]byte, discrSize)
+	if discrField.CanUint() {
+		v := discrField.Uint()
+		for i := range bytes {
+			bytes[i] = byte(v >> (8 * uint(i)))
+		}
+	} else if discrField.CanInt() {
+		v := discrField.Int()
+		for i := range bytes {
+			bytes[i] = byte(v >> (8 * uint(i)))
+		}
+	} else {
+		return ptr, free, fmt.Errorf("discriminant field type %s not int/uint", discrField.Type())
+	}
+	if !opts.Memory.Write(discrPtr, bytes) {
+		return ptr, free, fmt.Errorf("failed to write discriminant at %d", discrPtr)
+	}
+
+	discrVal := uint64(0)
+	if discrField.CanUint() {
+		discrVal = discrField.Uint()
+	} else {
+		discrVal = uint64(discrField.Int())
+	}
+	caseIndex := int(discrVal)
+	numCases := rv.NumField() - 1
+	if caseIndex < 0 || caseIndex >= numCases {
+		return ptr, free, fmt.Errorf("variant discriminant %d out of range [0,%d)", caseIndex, numCases)
+	}
+	activeField := rv.Field(caseIndex + 1)
+	if activeField.Kind() == reflect.Struct && activeField.Type().NumField() == 0 {
+		return ptr, free, nil // empty payload
+	}
+	valuePtr := AlignTo(discrPtr+discrSize, AlignmentOf(activeField.Interface()))
+	_, valueFree, err := Write(opts, activeField.Interface(), &valuePtr)
+	freeCallbacks = append(freeCallbacks, valueFree)
+	if err != nil {
+		return ptr, free, fmt.Errorf("failed to write variant payload: %w", err)
+	}
+	return ptr, free, nil
+}
+
+// WriteParameterVariant flattens the discriminant plus the active case payload parameters.
+func WriteParameterVariant(opts AbiOptions, value any) (params []Parameter, free AbiFreeCallback, err error) {
+	params = []Parameter{}
+	freeCallbacks := []AbiFreeCallback{}
+	free = wrapFreeCallbacks(&freeCallbacks)
+
+	rv := reflect.ValueOf(value)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if !rv.IsValid() {
+		return params, free, errors.New("must pass a valid variant value")
+	}
+	if !isStructVariantType(rv) {
+		return params, free, fmt.Errorf("value must be a variant, got %s", rv.Kind())
+	}
+	if rv.NumField() == 0 {
+		return params, free, errors.New("variant struct missing fields")
+	}
+
+	discrField := rv.Field(0)
+	discrUint := uint64(0)
+	if discrField.CanUint() {
+		discrUint = discrField.Uint()
+	} else if discrField.CanInt() {
+		discrUint = uint64(discrField.Int())
+	} else {
+		return params, free, fmt.Errorf("discriminant field type %s not int/uint", discrField.Type())
+	}
+	caseIndex := int(discrUint)
+	numCases := rv.NumField() - 1
+	if caseIndex < 0 || caseIndex >= numCases {
+		return params, free, fmt.Errorf("variant discriminant %d out of range [0,%d)", caseIndex, numCases)
+	}
+
+	discrParam := Parameter{
+		Value:     discrUint,
+		Size:      SizeOf(discrField.Interface()),
+		Alignment: AlignmentOf(discrField.Interface()),
+	}
+	params = append(params, discrParam)
+
+	activeField := rv.Field(caseIndex + 1)
+	if activeField.Kind() == reflect.Struct && activeField.Type().NumField() == 0 {
+		return params, free, nil // empty payload – only discriminant
+	}
+	fieldParams, fieldFree, err := WriteParameter(opts, activeField.Interface())
+	freeCallbacks = append(freeCallbacks, fieldFree)
+	if err != nil {
+		return params, free, fmt.Errorf("failed to write variant payload parameters: %w", err)
+	}
+	params = append(params, fieldParams...)
+	return params, free, nil
+}

--- a/pkg/abi/variant_test.go
+++ b/pkg/abi/variant_test.go
@@ -1,0 +1,95 @@
+package abi_test
+
+import (
+	"testing"
+
+	"github.com/rioam2/witigo/pkg/abi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Synthetic variant mirroring code generation pattern
+type SampleVariantType int
+
+const (
+	SampleVariantTypeA SampleVariantType = 0
+	SampleVariantTypeB SampleVariantType = 1
+	SampleVariantTypeC SampleVariantType = 2
+)
+
+type SampleVariant struct {
+	Type SampleVariantType
+	A    struct{}
+	B    uint32
+	C    string
+}
+
+func TestWriteParameterVariant(t *testing.T) {
+	opts := createAbiOptionsFromMemoryMap(nil)
+	v := SampleVariant{Type: SampleVariantTypeB, B: 0xDEADBEEF}
+	params, free, err := abi.WriteParameters(opts, v)
+	require.NoError(t, err)
+	defer free()
+	// Expect discriminant + uint32 (flattened as single param)
+	require.Len(t, params, 2)
+	assert.Equal(t, uint64(SampleVariantTypeB), params[0])
+	assert.Equal(t, uint64(0xDEADBEEF), params[1])
+}
+
+func TestVariantRoundTripEmptyCase(t *testing.T) {
+	opts := createAbiOptionsFromMemoryMap(nil)
+	original := SampleVariant{Type: SampleVariantTypeA}
+	ptr, free, err := abi.Write(opts, original, nil)
+	require.NoError(t, err)
+	defer free()
+	var decoded SampleVariant
+	err = abi.Read(opts, ptr, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, original.Type, decoded.Type)
+}
+
+func TestVariantRoundTripPayloadCases(t *testing.T) {
+	opts := createAbiOptionsFromMemoryMap(nil)
+	cases := []SampleVariant{
+		{Type: SampleVariantTypeB, B: 42},
+		{Type: SampleVariantTypeC, C: "hello"},
+		{Type: SampleVariantTypeC, C: ""},                                                     // empty string case
+		{Type: SampleVariantTypeB, B: 0},                                                      // zero value case
+		{Type: SampleVariantTypeB, B: 0xFFFFFFFF},                                             // max uint32
+		{Type: SampleVariantTypeC, C: "A longer string to test string handling in variants."}, // long string
+		{Type: SampleVariantTypeA},                                                            // empty case again
+	}
+	for _, c := range cases {
+		ptr, free, err := abi.Write(opts, c, nil)
+		require.NoError(t, err)
+		var decoded SampleVariant
+		err = abi.Read(opts, ptr, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, c.Type, decoded.Type)
+		switch c.Type {
+		case SampleVariantTypeB:
+			assert.Equal(t, c.B, decoded.B)
+		case SampleVariantTypeC:
+			assert.Equal(t, c.C, decoded.C)
+		}
+		free()
+	}
+}
+
+func TestVariantErrors(t *testing.T) {
+	opts := createAbiOptionsFromMemoryMap(nil)
+	// Invalid discriminant when reading
+	// Write bytes manually with out-of-range discriminant (e.g., 5)
+	opts.Memory.Write(0, []byte{5, 0, 0, 0, 0, 0, 0, 0}) // discriminant stored as 8-byte int
+	var v SampleVariant
+	err := abi.ReadVariant(opts, 0, &v)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+
+	// Writing with invalid case index (manually craft struct) not possible via type-safe API,
+	// but we can simulate by setting discriminant > cases and calling WriteVariant.
+	bad := SampleVariant{Type: SampleVariantType(99)}
+	_, _, err = abi.WriteVariant(opts, bad, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}

--- a/pkg/abi/variant_test.go
+++ b/pkg/abi/variant_test.go
@@ -1,6 +1,7 @@
 package abi_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/rioam2/witigo/pkg/abi"
@@ -94,4 +95,121 @@ func TestVariantErrors(t *testing.T) {
 	_, _, err = abi.WriteVariant(opts, bad, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "out of range")
+}
+
+// Record type for nested payload usage
+type NestedRecord struct {
+	X int16
+	Y uint64
+}
+
+// ComplexVariant tests joining across integer, float, string, list and empty cases.
+// Case ordering chosen to force widening (i32 vs f32 -> i32, i32 vs i64 -> i64) behavior.
+type ComplexVariantType int
+
+const (
+	ComplexVariantTypeEmpty  ComplexVariantType = iota
+	ComplexVariantTypeNumber                    // int32 payload
+	ComplexVariantTypeFloat                     // float32 payload (joins with int32 -> i32 slot)
+	ComplexVariantTypeBig                       // uint64 payload (forces widening to i64)
+	ComplexVariantTypeText                      // string payload (adds two i32 slots)
+	ComplexVariantTypeList                      // []uint8 payload (pointer+len two i32 slots)
+	ComplexVariantTypeRecord                    // nestedRecord payload (two fields -> i32 + i64 -> widens first to i64 total slots maybe 2)
+)
+
+type ComplexVariant struct {
+	Type   ComplexVariantType
+	Empty  struct{}
+	Number int32
+	Float  float32
+	Big    uint64
+	Text   string
+	List   []uint8
+	Record NestedRecord
+}
+
+// buildComplexCases returns instances of ComplexVariant covering all payload kinds.
+func buildComplexCases() []ComplexVariant {
+	return []ComplexVariant{
+		{Type: ComplexVariantTypeEmpty},
+		{Type: ComplexVariantTypeNumber, Number: 12345},
+		{Type: ComplexVariantTypeFloat, Float: 3.14},
+		{Type: ComplexVariantTypeBig, Big: math.MaxUint64},
+		{Type: ComplexVariantTypeText, Text: "hi"},
+		{Type: ComplexVariantTypeText, Text: ""}, // empty string
+		{Type: ComplexVariantTypeList, List: []uint8{1, 2, 3, 4}},
+		{Type: ComplexVariantTypeList, List: []uint8{}},
+		{Type: ComplexVariantTypeRecord, Record: NestedRecord{X: -7, Y: 99}},
+	}
+}
+
+func TestComplexVariantParameterFlatteningShapeConsistency(t *testing.T) {
+	opts := createAbiOptionsFromMemoryMap(nil)
+	cases := buildComplexCases()
+	var expectedLen int = -1
+	for _, c := range cases {
+		flat, free, err := abi.WriteParameters(opts, c)
+		require.NoError(t, err)
+		if expectedLen == -1 {
+			expectedLen = len(flat)
+		} else {
+			assert.Equal(t, expectedLen, len(flat), "all complex variant param lists must have same length")
+		}
+		// Discriminant must always be first
+		assert.Equal(t, uint64(c.Type), flat[0])
+		free()
+	}
+	assert.GreaterOrEqual(t, expectedLen, 2) // Should have at least discriminant + one payload slot
+}
+
+func TestComplexVariantRoundTrip(t *testing.T) {
+	opts := createAbiOptionsFromMemoryMap(nil)
+	for _, c := range buildComplexCases() {
+		ptr, free, err := abi.Write(opts, c, nil)
+		require.NoError(t, err)
+		var decoded ComplexVariant
+		err = abi.Read(opts, ptr, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, c.Type, decoded.Type)
+		switch c.Type {
+		case ComplexVariantTypeNumber:
+			assert.Equal(t, c.Number, decoded.Number)
+		case ComplexVariantTypeFloat:
+			assert.InDelta(t, c.Float, decoded.Float, 1e-6)
+		case ComplexVariantTypeBig:
+			assert.Equal(t, c.Big, decoded.Big)
+		case ComplexVariantTypeText:
+			assert.Equal(t, c.Text, decoded.Text)
+		case ComplexVariantTypeList:
+			assert.Equal(t, c.List, decoded.List)
+		case ComplexVariantTypeRecord:
+			assert.Equal(t, c.Record, decoded.Record)
+		}
+		free()
+	}
+}
+
+func TestComplexVariantInvalidDiscriminantRead(t *testing.T) {
+	// Craft memory with invalid discriminant for ComplexVariant (e.g., 99)
+	opts := createAbiOptionsFromMemoryMap(map[uint64][]byte{
+		0: {99, 0, 0, 0, 0, 0, 0, 0},
+	})
+	var cv ComplexVariant
+	err := abi.ReadVariant(opts, 0, &cv)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}
+
+func TestComplexVariantParameterMismatchAfterTypeChange(t *testing.T) {
+	// Simulate user mistakenly changing discriminant after preparing payload
+	opts := createAbiOptionsFromMemoryMap(nil)
+	v := ComplexVariant{Type: ComplexVariantTypeText, Text: "hello"}
+	flat, free, err := abi.WriteParameters(opts, v)
+	require.NoError(t, err)
+	// Mutate discriminant to different case that expects scalar only
+	flat[0] = uint64(ComplexVariantTypeNumber)
+	// We cannot directly call into guest here, but we can assert shape still coherent
+	// and differs from naive encoding that would omit slots.
+	require.GreaterOrEqual(t, len(flat), 3)
+	free()
 }

--- a/pkg/abi/variant_test.go
+++ b/pkg/abi/variant_test.go
@@ -30,10 +30,12 @@ func TestWriteParameterVariant(t *testing.T) {
 	params, free, err := abi.WriteParameters(opts, v)
 	require.NoError(t, err)
 	defer free()
-	// Expect discriminant + uint32 (flattened as single param)
-	require.Len(t, params, 2)
+	// Flattened shape should be: discriminant + 2 slots (string case pointer,len) => 3 params
+	require.Len(t, params, 3)
 	assert.Equal(t, uint64(SampleVariantTypeB), params[0])
-	assert.Equal(t, uint64(0xDEADBEEF), params[1])
+	assert.Equal(t, uint64(0xDEADBEEF), params[1]) // B payload in first payload slot
+	// Third slot unused for this case => zero
+	assert.Equal(t, uint64(0), params[2])
 }
 
 func TestVariantRoundTripEmptyCase(t *testing.T) {

--- a/pkg/codegen/generate_type.go
+++ b/pkg/codegen/generate_type.go
@@ -2,7 +2,6 @@ package codegen
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/golang-cz/textcase"
 	"github.com/moznion/gowrtr/generator"
@@ -46,11 +45,6 @@ func GenerateTypenameFromType(w wit.WitType) string {
 		}
 		panic(fmt.Sprintf("Unknown WIT type kind: %s", kind))
 	}
-}
-
-func discriminantSize(n int) int {
-	bits := math.Ceil(math.Log2(float64(n))/8) * 8
-	return int(bits)
 }
 
 func generatePrimitiveTypenameFromType(w wit.WitType) string {

--- a/pkg/codegen/generate_type.go
+++ b/pkg/codegen/generate_type.go
@@ -215,8 +215,9 @@ func generateEnumTypedefFromType(w wit.WitType) *generator.Root {
 
 func generateVariantTypedefFromType(w wit.WitType) *generator.Root {
 	root := generator.NewRoot()
+	discriminantType := fmt.Sprintf("uint%d", discriminantSize(len(w.SubTypes())))
 	enumTypedefName := GenerateTypenameFromType(w) + "Type"
-	enumTypedef := generator.NewRawStatementf("type %s int", enumTypedefName)
+	enumTypedef := generator.NewRawStatementf("type %s %s", enumTypedefName, discriminantType)
 	root = root.AddStatements(enumTypedef)
 	for i, c := range w.SubTypes() {
 		statement := generator.NewRawStatementf(

--- a/pkg/codegen/util.go
+++ b/pkg/codegen/util.go
@@ -1,0 +1,18 @@
+package codegen
+
+import (
+	"math"
+)
+
+// discriminantSize returns the size in bits of the discriminant needed to represent n cases.
+func discriminantSize(n int) int {
+	bytesNeeded := int(math.Ceil(math.Log2(float64(n+1)) / 8.0))
+	switch bytesNeeded {
+	case 0, 1:
+		return 8
+	case 2:
+		return 16
+	default:
+		return 32
+	}
+}

--- a/pkg/codegen/util_test.go
+++ b/pkg/codegen/util_test.go
@@ -1,0 +1,58 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiscriminantSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		cases    int
+		expected int
+	}{
+		{
+			name:     "zero cases",
+			cases:    0,
+			expected: 8,
+		},
+		{
+			name:     "one case",
+			cases:    1,
+			expected: 8,
+		},
+		{
+			name:     "two cases",
+			cases:    2,
+			expected: 8,
+		},
+		{
+			name:     "255 cases",
+			cases:    255,
+			expected: 8,
+		},
+		{
+			name:     "256 cases",
+			cases:    256,
+			expected: 16,
+		},
+		{
+			name:     "65535 cases",
+			cases:    65535,
+			expected: 16,
+		},
+		{
+			name:     "65536 cases",
+			cases:    65536,
+			expected: 32,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := discriminantSize(tt.cases)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces support for variant types, including Go bindings, ABI utilities and integration tests. The ABI layer is updated to correctly handle variant types, including size and alignment calculations.

- Updated Go ABI utilities (`parameters.go`, `util.go`) to detect and handle variant types, including writing, reading, size, and alignment calculations for variants.
- Added comprehensive unit tests for both simple and complex variants in `main_test.go`, covering all transformation rules for the new complex variant type.